### PR TITLE
Upgrade Helm to 3.2.4 version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine
 ARG docker_ver=19.03.11
 ARG docker_compose_ver=1.26.0
 ARG kubectl_ver=1.18.3
-ARG helm_ver=3.2.3
+ARG helm_ver=3.2.4
 ARG helm2_ver=2.16.8
 ARG reg_ver=0.16.1
 

--- a/hooks/post_push
+++ b/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {0.7.0-docker19.03.11-compose1.26.0-kubectl1.18.3-helm3.2.3-helm2.16.8-reg0.16.1,0.7.0,0.7,latest}; do
+for tag in {0.7.0-docker19.03.11-compose1.26.0-kubectl1.18.3-helm3.2.4-helm2.16.8-reg0.16.1,0.7.0,0.7,latest}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done


### PR DESCRIPTION
[Helm v3.2.4 release notes][1] 

FCM
```
Upgrade Helm to 3.2.4 version (#27)
```

[1]: https://github.com/helm/helm/releases/tag/v3.2.4